### PR TITLE
Non-existent user vulnerability

### DIFF
--- a/src/services/access/access.repository.ts
+++ b/src/services/access/access.repository.ts
@@ -579,6 +579,9 @@ export class AccessRepository {
   ): Promise<void> {
     await this.db.ready();
 
+    /** make sure creatorId exist */
+    await this.userRepo.upsertProfile(toUserId);
+
     let ndelquads: string = '';
     let query = `
     var(func: eq(xid, ${elementId})) {

--- a/src/services/access/access.test.ts
+++ b/src/services/access/access.test.ts
@@ -11,7 +11,7 @@ import {
     createPerspective
 } from '../uprtcl/uprtcl.testsupport';
 
-describe('create perspectives with its parentIds', () => {
+describe('delegate behavior', () => {
     expect.extend({ toBeValidCid });  
     
     const creatorId = 'did:method:12345';    


### PR DESCRIPTION
Added a line to create a user that does not exist in the DB when adding permissions to a specific user.