### PR TITLE
Review permissions

### DIFF
--- a/src/services/access/access.service.ts
+++ b/src/services/access/access.service.ts
@@ -51,6 +51,8 @@ export class AccessService {
       throw new Error(`ElementId is empty`);
 
     let accessConfig: AccessConfig;
+    let dftPermUid = await this.createDefaultPermissions(userId);
+
     if (delegateTo) {
       if (userId == null)
         throw new Error('cant inherit permissions if user is not logged in');
@@ -65,10 +67,9 @@ export class AccessService {
         delegate: true,
         delegateTo,
         finDelegatedTo,
-        permissionsUid: delegateAccessConfig.permissionsUid,
+        permissionsUid: dftPermUid,
       };
-    } else {
-      let dftPermUid = await this.createDefaultPermissions(userId);
+    } else {      
       accessConfig = {
         delegate: false,
         finDelegatedTo: elementId,        

--- a/src/services/access/access.test.ts
+++ b/src/services/access/access.test.ts
@@ -4,6 +4,7 @@ import {
     finDelegatedChildNodes,
     getSecondLayerFinDelegatedTo,
     getAccessConfigOfElement,
+    getPermissionsConfig,
     addPermission
 } from './access.testsupport';
 import { PermissionType } from './access.schema';
@@ -115,38 +116,46 @@ describe('delegate behavior', () => {
         */
 
         // Then, get the permissions of the above obtained element
-        const perspPermissions = await getAccessConfigOfElement(finDelegatedTo);          
-                
-        
+        const perspAccessConfig = await getAccessConfigOfElement(finDelegatedTo);  
+        const perspBAccessConfig = await getAccessConfigOfElement(perspectiveB);         
+                        
         // Add permissions to finDelegatedTo
-        // await addPermission(
-        //     finDelegatedTo,
-        //     user2.userId,
-        //     PermissionType.Read,
-        //     user1.jwt
-        // );
+        await addPermission(
+            finDelegatedTo,
+            user2.userId,
+            PermissionType.Read,
+            user1.jwt
+        );
         
-        // await addPermission(
-        //     finDelegatedTo,
-        //     user3.userId,
-        //     PermissionType.Read,
-        //     user1.jwt
-        // );
+        await addPermission(
+            finDelegatedTo,
+            user3.userId,
+            PermissionType.Read,
+            user1.jwt
+        );        
 
-        // Add permissions to perspectiveB
-        // await addPermission(
-        //     perspectiveB,
-        //     user4.userId,
-        //     PermissionType.Write,
-        //     user1.jwt
-        // );
+        //Add permissions to perspectiveB
+        await addPermission(
+            perspectiveB,
+            user4.userId,
+            PermissionType.Write,
+            user1.jwt
+        );
 
-        // await addPermission(
-        //     perspectiveB,
-        //     user3.userId,
-        //     PermissionType.Write,
-        //     user1.jwt
-        // );
+        await addPermission(
+            perspectiveB,
+            user3.userId,
+            PermissionType.Write,
+            user1.jwt
+        );       
+
+        const perspPermissions = await getPermissionsConfig(perspAccessConfig.permissionsUid!);
+        const perspBPermissions = await getPermissionsConfig(perspBAccessConfig.permissionsUid!);
+
+        // Permissions before delegating to false
+        expect(perspBPermissions.canWrite![0]).toEqual(user3.userId.toLowerCase());
+        expect(perspBPermissions.canWrite![1]).toEqual(user4.userId.toLowerCase());
+        expect(perspBPermissions.canAdmin![0]).toEqual(user1.userId.toLowerCase());
 
         // From true to false
         const delegateToB = await delegatePermissionsTo(
@@ -155,56 +164,55 @@ describe('delegate behavior', () => {
             undefined,
             user1.jwt
         );
-        expect(delegateToB.result).toEqual(SUCCESS);    
+        expect(delegateToB.result).toEqual(SUCCESS);            
 
-    //     const perspBElementPermissions = await getAccessConfigOfElement(perspectiveB);     
+        // Permissions of B after delegate false
+        const perspFalsePermissions = await getPermissionsConfig(perspBAccessConfig.permissionsUid!);
+            
+        // Checks how permissions are cloned
+        // Permissions after delegating to false
+        expect(perspPermissions).toEqual(perspFalsePermissions);
 
-    //     expect(perspBElementPermissions.permissionsUid).toEqual(perspPermissions.permissionsUid);
+        // Checks all finDelegatedTo of perspectiveB children.
+        childrenB = await finDelegatedChildNodes(perspectiveB);                        
 
-    //     // Checks all finDelegatedTo of perspectiveB children.
-    //     childrenB = await finDelegatedChildNodes(perspectiveB);                        
+        expect(Array.from(new Set(childrenB))).toHaveLength(1);
+        expect(Array.from(new Set(childrenB))).toEqual([perspectiveB]);
 
-    //     expect(Array.from(new Set(childrenB))).toHaveLength(1);
-    //     expect(Array.from(new Set(childrenB))).toEqual([perspectiveB]);
+        // From false to true
+        const delegateToA = await delegatePermissionsTo(
+            perspectiveB,
+            true, 
+            perspectiveA, 
+            user1.jwt
+        );        
 
-    //     // From false to true
-    //     const delegateToA = await delegatePermissionsTo(
-    //         perspectiveB,
-    //         true, 
-    //         perspectiveA, 
-    //         user1.jwt
-    //     );        
+        expect(delegateToA.result).toEqual(SUCCESS);        
 
-    //     expect(delegateToA.result).toEqual(SUCCESS);        
-
-    //     childrenB = await finDelegatedChildNodes(perspectiveB);                        
+        childrenB = await finDelegatedChildNodes(perspectiveB);                        
         
-    //     // Checks child nodes
-    //     expect(Array.from(new Set(childrenB))).toHaveLength(1);
-    //     expect(Array.from(new Set(childrenB))).toEqual([perspectiveA]);
+        // Checks child nodes
+        expect(Array.from(new Set(childrenB))).toHaveLength(1);
+        expect(Array.from(new Set(childrenB))).toEqual([perspectiveA]);
 
-    //     //------------------------------
+        //------------------------------
 
-    //     // Different scenario of true to false and cloning.    
-    //    const finDelegatedToD1 = await getSecondLayerFinDelegatedTo(perspectiveD1);
+        // Different scenario of true to false and cloning.    
+       const finDelegatedToD1 = await getSecondLayerFinDelegatedTo(perspectiveD1);
         
-    //    // Which result should be the perspectiveA
-    //    expect(finDelegatedToD1).toEqual(perspectiveA);             
+       // Which result should be the perspectiveA
+       expect(finDelegatedToD1).toEqual(perspectiveA);             
 
-    //    // Then, get the permissions of the above obtained element
-    //    const rsD1Permissions = await getAccessConfigOfElement(finDelegatedToD1);          
+       // Then, get the permissions of the above obtained element
+       const rsD1Permissions = await getAccessConfigOfElement(finDelegatedToD1);          
                 
-    //    // From true to false
-    //    const delegaToD1 = await delegatePermissionsTo(
-    //        perspectiveD1, 
-    //        false, 
-    //        undefined,
-    //        user1.jwt
-    //    );
-    //    expect(delegaToD1.result).toEqual(SUCCESS);    
-
-    //    const D1Permissions = await getAccessConfigOfElement(perspectiveD1);     
-
-    //    expect(D1Permissions.permissionsUid).toEqual(rsD1Permissions.permissionsUid);
+       // From true to false
+       const delegaToD1 = await delegatePermissionsTo(
+           perspectiveD1, 
+           false, 
+           undefined,
+           user1.jwt
+       );
+       expect(delegaToD1.result).toEqual(SUCCESS);    
     });    
 });

--- a/src/services/access/access.test.ts
+++ b/src/services/access/access.test.ts
@@ -3,8 +3,10 @@ import {
     delegatePermissionsTo,
     finDelegatedChildNodes,
     getSecondLayerFinDelegatedTo,
-    getAccessConfigOfElement
+    getAccessConfigOfElement,
+    addPermission
 } from './access.testsupport';
+import { PermissionType } from './access.schema';
 import { createUser } from '../user/user.testsupport';
 import {
     createCommitAndData, 
@@ -23,7 +25,10 @@ describe('delegate behavior', () => {
     let perspectiveC1 = '';        
    
     it('should update all finDelegatedTo of all children and clone permissions', async () => {
-        user1 = await createUser('seed1');        
+        user1 = await createUser('seed1');   
+        const user2 = await createUser('seed2');
+        const user3 = await createUser('seed3');
+        const user4 = await createUser('seed4');
 
         const commitA = await createCommitAndData('perspective A', false, user1.jwt);
         perspectiveA = await createPerspective(
@@ -112,6 +117,37 @@ describe('delegate behavior', () => {
         // Then, get the permissions of the above obtained element
         const perspPermissions = await getAccessConfigOfElement(finDelegatedTo);          
                 
+        
+        // Add permissions to finDelegatedTo
+        // await addPermission(
+        //     finDelegatedTo,
+        //     user2.userId,
+        //     PermissionType.Read,
+        //     user1.jwt
+        // );
+        
+        // await addPermission(
+        //     finDelegatedTo,
+        //     user3.userId,
+        //     PermissionType.Read,
+        //     user1.jwt
+        // );
+
+        // Add permissions to perspectiveB
+        // await addPermission(
+        //     perspectiveB,
+        //     user4.userId,
+        //     PermissionType.Write,
+        //     user1.jwt
+        // );
+
+        // await addPermission(
+        //     perspectiveB,
+        //     user3.userId,
+        //     PermissionType.Write,
+        //     user1.jwt
+        // );
+
         // From true to false
         const delegateToB = await delegatePermissionsTo(
             perspectiveB, 
@@ -121,54 +157,54 @@ describe('delegate behavior', () => {
         );
         expect(delegateToB.result).toEqual(SUCCESS);    
 
-        const perspBElementPermissions = await getAccessConfigOfElement(perspectiveB);     
+    //     const perspBElementPermissions = await getAccessConfigOfElement(perspectiveB);     
 
-        expect(perspBElementPermissions.permissionsUid).toEqual(perspPermissions.permissionsUid);
+    //     expect(perspBElementPermissions.permissionsUid).toEqual(perspPermissions.permissionsUid);
 
-        // Checks all finDelegatedTo of perspectiveB children.
-        childrenB = await finDelegatedChildNodes(perspectiveB);                        
+    //     // Checks all finDelegatedTo of perspectiveB children.
+    //     childrenB = await finDelegatedChildNodes(perspectiveB);                        
 
-        expect(Array.from(new Set(childrenB))).toHaveLength(1);
-        expect(Array.from(new Set(childrenB))).toEqual([perspectiveB]);
+    //     expect(Array.from(new Set(childrenB))).toHaveLength(1);
+    //     expect(Array.from(new Set(childrenB))).toEqual([perspectiveB]);
 
-        // From false to true
-        const delegateToA = await delegatePermissionsTo(
-            perspectiveB,
-            true, 
-            perspectiveA, 
-            user1.jwt
-        );        
+    //     // From false to true
+    //     const delegateToA = await delegatePermissionsTo(
+    //         perspectiveB,
+    //         true, 
+    //         perspectiveA, 
+    //         user1.jwt
+    //     );        
 
-        expect(delegateToA.result).toEqual(SUCCESS);        
+    //     expect(delegateToA.result).toEqual(SUCCESS);        
 
-        childrenB = await finDelegatedChildNodes(perspectiveB);                        
+    //     childrenB = await finDelegatedChildNodes(perspectiveB);                        
         
-        // Checks child nodes
-        expect(Array.from(new Set(childrenB))).toHaveLength(1);
-        expect(Array.from(new Set(childrenB))).toEqual([perspectiveA]);
+    //     // Checks child nodes
+    //     expect(Array.from(new Set(childrenB))).toHaveLength(1);
+    //     expect(Array.from(new Set(childrenB))).toEqual([perspectiveA]);
 
-        //------------------------------
+    //     //------------------------------
 
-        // Different scenario of true to false and cloning.    
-       const finDelegatedToD1 = await getSecondLayerFinDelegatedTo(perspectiveD1);
+    //     // Different scenario of true to false and cloning.    
+    //    const finDelegatedToD1 = await getSecondLayerFinDelegatedTo(perspectiveD1);
         
-       // Which result should be the perspectiveA
-       expect(finDelegatedToD1).toEqual(perspectiveA);             
+    //    // Which result should be the perspectiveA
+    //    expect(finDelegatedToD1).toEqual(perspectiveA);             
 
-       // Then, get the permissions of the above obtained element
-       const rsD1Permissions = await getAccessConfigOfElement(finDelegatedToD1);          
+    //    // Then, get the permissions of the above obtained element
+    //    const rsD1Permissions = await getAccessConfigOfElement(finDelegatedToD1);          
                 
-       // From true to false
-       const delegaToD1 = await delegatePermissionsTo(
-           perspectiveD1, 
-           false, 
-           undefined,
-           user1.jwt
-       );
-       expect(delegaToD1.result).toEqual(SUCCESS);    
+    //    // From true to false
+    //    const delegaToD1 = await delegatePermissionsTo(
+    //        perspectiveD1, 
+    //        false, 
+    //        undefined,
+    //        user1.jwt
+    //    );
+    //    expect(delegaToD1.result).toEqual(SUCCESS);    
 
-       const D1Permissions = await getAccessConfigOfElement(perspectiveD1);     
+    //    const D1Permissions = await getAccessConfigOfElement(perspectiveD1);     
 
-       expect(D1Permissions.permissionsUid).toEqual(rsD1Permissions.permissionsUid);
+    //    expect(D1Permissions.permissionsUid).toEqual(rsD1Permissions.permissionsUid);
     });    
 });

--- a/src/services/access/access.testsupport.ts
+++ b/src/services/access/access.testsupport.ts
@@ -67,6 +67,10 @@ export const getAccessConfigOfElement = async (elementId: string) => {
   return await accessRepo.getAccessConfigOfElement(elementId);
 };
 
+export const getPermissionsConfig = async (permissionsUid: string) => {
+  return await accessRepo.getPermissionsConfig(permissionsUid);
+};
+
 export const addPermission = async (
   elementId: string,
   userToAddId: string,

--- a/src/services/uprtcl/uprtcl.repository.ts
+++ b/src/services/uprtcl/uprtcl.repository.ts
@@ -253,7 +253,6 @@ export class UprtclRepository {
 
     /**  */
     const mu = new dgraph.Mutation();
-    const condMutation = new dgraph.Mutation();
     const req = new dgraph.Request();
 
     let query = `perspective as var(func: eq(xid, "${perspectiveId}"))`;
@@ -290,7 +289,7 @@ export class UprtclRepository {
     mu.setSetNquads(ecosystemUpdated.nquads);        
     mu.setDelNquads(ecosystemUpdated.delNquads);
 
-    req.setMutationsList([mu, condMutation]);
+    req.setMutationsList([mu]);
 
     let result = await this.db.callRequest(req);
 


### PR DESCRIPTION
Hello there!, finally I properly finished the functionality that enables the API to clone permissions. The problem with the random UID created at the time of adding inherited permissions came from a `dgraph` wrong design and semantic implementation problem during my development.

Let's suppose we have the following query:

![image](https://user-images.githubusercontent.com/16869766/93545459-0c615400-f926-11ea-92f6-7d7002371ae9.png)

And, let's suppose that the `canWrite` array came as empty. If I use the `userCw` variable being this array with a length of zero, `dgraph` will automatically create an empty node inside the mutation, that is why the use of `conditions` solves the problem, because if the array comes empty, the logic will ignore the mutation, and will be able to create a clean upsert.