### PR TITLE
Add update protection

### DIFF
--- a/src/services/access/access.repository.ts
+++ b/src/services/access/access.repository.ts
@@ -207,7 +207,7 @@ export class AccessRepository {
   canUpdateQuery(updateId: string, query: string, userId: string) {
     query = query.concat(
       `\nprivate${updateId} as var(func: eq(xid, ${updateId})) @cascade {
-          canWrite @filter(eq(did, ${userId})) {
+          canWrite @filter(eq(did, "${userId}")) {
             did
           }
         }
@@ -264,13 +264,13 @@ export class AccessRepository {
   ): Promise<UserPermissions> {
     let query = `
     element(func: eq(xid, "${elementId}")) {
-      canRead @filter(eq(did, "${userId.toLowerCase()}")) {
+      canRead @filter(eq(did, "${userId}")) {
         count(uid)
       }
-      canWrite @filter(eq(did, "${userId.toLowerCase()}")) {
+      canWrite @filter(eq(did, "${userId}")) {
         count(uid)
       }
-      canAdmin @filter(eq(did, "${userId.toLowerCase()}")) {
+      canAdmin @filter(eq(did, "${userId}")) {
         count(uid)
       }
     }`;

--- a/src/services/access/access.repository.ts
+++ b/src/services/access/access.repository.ts
@@ -183,11 +183,10 @@ export class AccessRepository {
     updates: Update[],
     loggedUserId: string
   ): Promise<boolean> {
-    const userId = this.userRepo.formatDid(loggedUserId);
     let query = '';
 
     for (let i = 0; i < updates.length; i++) {
-      const queryString = this.canUpdateQuery(updates[i].perspectiveId, query, userId);
+      const queryString = this.canUpdateQuery(updates[i].perspectiveId, query, loggedUserId);
 
       if(i < 1) {
         query = query.concat(queryString);

--- a/src/services/access/access.service.ts
+++ b/src/services/access/access.service.ts
@@ -9,6 +9,7 @@ import {
 import { NOT_AUTHORIZED_MSG } from '../../utils';
 import { PermissionType } from '../uprtcl/types';
 import { DgUpdate } from '../proposals/types';
+import { Update } from '@uprtcl/evees';
 
 require('dotenv').config();
 
@@ -191,6 +192,16 @@ export class AccessService {
     }
 
     return this.accessRepo.can(permissionsElement, userId, type);
+  }
+
+  async canUpdate(
+    updates: Update[],
+    loggedUserId: string
+  ): Promise<boolean> {
+    if(loggedUserId === null)
+      throw new Error('Anonymous user. Cant update a perspective');
+    
+    return await this.accessRepo.canUpdate(updates, loggedUserId);
   }
 
   async setPublic(

--- a/src/services/uprtcl/uprtcl.repository.ts
+++ b/src/services/uprtcl/uprtcl.repository.ts
@@ -160,11 +160,10 @@ export class UprtclRepository {
 
     let { query, nquads } = upsert;
 
-    const did = this.userRepo.formatDid(creatorId);
 
-    if (!upsertedProfiles.includes(did)) {
-      upsertedProfiles.push(did);
-      const creatorSegment = this.userRepo.upsertQueries(did);
+    if (!upsertedProfiles.includes(creatorId)) {
+      upsertedProfiles.push(creatorId);
+      const creatorSegment = this.userRepo.upsertQueries(creatorId);
       query = query.concat(creatorSegment.query);
       nquads = nquads.concat(creatorSegment.nquads);
     }
@@ -182,7 +181,7 @@ export class UprtclRepository {
 
     nquads = nquads.concat(`\nuid(persp${id}) <xid> "${id}" .`);
     nquads = nquads.concat(`\nuid(persp${id}) <stored> "true" .`);
-    nquads = nquads.concat(`\nuid(persp${id}) <creator> uid(profile${did}) .`);
+    nquads = nquads.concat(`\nuid(persp${id}) <creator> uid(profile${this.userRepo.formatDid(creatorId)}) .`);
     nquads = nquads.concat(
       `\nuid(persp${id}) <timextamp> "${timestamp}"^^<xs:int> .`
     );
@@ -212,9 +211,9 @@ export class UprtclRepository {
     nquads = nquads.concat(
       `\nuid(persp${id}) <publicRead> "false" .
        \nuid(persp${id}) <publicWrite> "false" .
-       \nuid(persp${id}) <canRead> uid(profile${did}) .
-       \nuid(persp${id}) <canWrite> uid(profile${did}) .
-       \nuid(persp${id}) <canAdmin> uid(profile${did}) .`
+       \nuid(persp${id}) <canRead> uid(profile${this.userRepo.formatDid(creatorId)}) .
+       \nuid(persp${id}) <canWrite> uid(profile${this.userRepo.formatDid(creatorId)}) .
+       \nuid(persp${id}) <canAdmin> uid(profile${this.userRepo.formatDid(creatorId)}) .`
     );
 
     /** add itself as its ecosystem */
@@ -846,7 +845,7 @@ export class UprtclRepository {
     loggedUserId: string | null
   ): Promise<ParentAndChild[]> {
     await this.db.ready();
-    const userId = this.userRepo.formatDid((loggedUserId !== null) ? loggedUserId : '');
+    const userId = loggedUserId !== null ? loggedUserId : '';
 
     const parentsPortion = `
     {
@@ -922,7 +921,7 @@ export class UprtclRepository {
   ): Promise<PerspectiveGetResult> {
     await this.db.ready();
 
-    const userId = this.userRepo.formatDid((loggedUserId !== null) ? this.userRepo.formatDid(loggedUserId) : '');
+    const userId = (loggedUserId !== null) ? loggedUserId : '';
 
     if (options.levels !== 0 && options.levels !== -1) {
       throw new Error(

--- a/src/services/uprtcl/uprtcl.service.ts
+++ b/src/services/uprtcl/uprtcl.service.ts
@@ -56,7 +56,8 @@ export class UprtclService {
     await this.uprtclRepo.createPerspectives(perspectivesData, loggedUserId);
 
     await this.uprtclRepo.updatePerspectives(
-      perspectivesData.map((newPerspective) => newPerspective.update)
+      perspectivesData.map((newPerspective) => newPerspective.update),
+      loggedUserId
     );
 
     return [];
@@ -70,8 +71,9 @@ export class UprtclService {
      * What about the access control? We might need to find a way to check
      * if the user can write a perspective, we used to call access.can(id, userId, permisstions)
      */
-    // update needs to be done one by one to manipulate the ecosystem links
-    await this.uprtclRepo.updatePerspectives(updates);
+    if(loggedUserId === null)
+      throw new Error('Anonymous user. Cant update a perspective');
+    await this.uprtclRepo.updatePerspectives(updates,loggedUserId);
   }
 
   async deletePerspective(

--- a/src/services/uprtcl/uprtcl.service.ts
+++ b/src/services/uprtcl/uprtcl.service.ts
@@ -56,8 +56,7 @@ export class UprtclService {
     await this.uprtclRepo.createPerspectives(perspectivesData, loggedUserId);
 
     await this.uprtclRepo.updatePerspectives(
-      perspectivesData.map((newPerspective) => newPerspective.update),
-      loggedUserId
+      perspectivesData.map((newPerspective) => newPerspective.update)
     );
 
     return [];
@@ -73,7 +72,13 @@ export class UprtclService {
      */
     if(loggedUserId === null)
       throw new Error('Anonymous user. Cant update a perspective');
-    await this.uprtclRepo.updatePerspectives(updates,loggedUserId);
+
+    const canUpdate = await this.access.canUpdate(updates, loggedUserId);
+
+    if(!canUpdate)
+      throw new Error('Anonymous user. Cant update a perspective');
+
+    await this.uprtclRepo.updatePerspectives(updates);
   }
 
   async deletePerspective(


### PR DESCRIPTION
The applied is the second solution, one additional transaction to check user permissions on every element of the batch throughout a single Dgraph query. #39 