### PR TITLE
Fixed independent perspective bussines logic.

### DIFF
--- a/src/services/uprtcl/uprtcl.repository.ts
+++ b/src/services/uprtcl/uprtcl.repository.ts
@@ -728,14 +728,14 @@ export class UprtclRepository {
        */
       if (independent) {
         // Verify indepent perspectives criteria with parents
-        query = query.concat(`\nchildren(func: uid(eco)) @filter(not(uid(persp))) {
-          context {
-            childrenContext as uid
-          }
-          ~children {
-            context {
-              parentContext as uid
+        query = query.concat(`\nrecurseChildren(func: uid(eco)) @filter(not(uid(persp))) {
+          children {
+						context {
+              childrenContext as uid
             }
+          }
+          context {
+            parentContext as uid
           }
         }
         normalRef(func: uid(childrenContext)) {
@@ -1781,6 +1781,8 @@ export class UprtclRepository {
         optionalWrapper = optionalWrapper.replace('ecosystem', '~ecosystem');
       }
     }
+
+    console.log(optionalWrapper);
 
     return {
       startQuery,

--- a/src/services/uprtcl/uprtcl.repository.ts
+++ b/src/services/uprtcl/uprtcl.repository.ts
@@ -728,6 +728,14 @@ export class UprtclRepository {
        */
       if (independent) {
         // Verify indepent perspectives criteria with parents
+
+        /**
+         * In the query below called @recurseChildren, we retrieve the context of:
+         * a) The *children of the previous recurse query result a.k.a eco*, whether the query
+         * is aimed at walking the tree downwards ("under" asking for children) or upwards ("above"
+         * asking for parents) also known as children context.
+         * b) The *previous recurse query result* also know as the parent context.
+         */
         query = query.concat(`\nrecurseChildren(func: uid(eco)) @filter(not(uid(persp))) {
           children {
 						context {

--- a/src/services/uprtcl/uprtcl.repository.ts
+++ b/src/services/uprtcl/uprtcl.repository.ts
@@ -1782,8 +1782,6 @@ export class UprtclRepository {
       }
     }
 
-    console.log(optionalWrapper);
-
     return {
       startQuery,
       internalWrapper,


### PR DESCRIPTION
As per the "independent" definition: _refers/applies exclusively to children and children of chilren (it does not applies to the top level)_.

I misunderstood the definition by not taking into account the "_children and the children of the children_" which would be nothing more than the children of the recurse query result, whether that result is parent or child, in order to be able to properly walk the whole tree with flexibility.